### PR TITLE
Added all constant declarations, GSL_FAILURE, GSL_CONTINUE etc.

### DIFF
--- a/cython_gsl/__init__.pxd
+++ b/cython_gsl/__init__.pxd
@@ -19,7 +19,7 @@ from libc.stdio cimport *
 
 cdef enum:
   GSL_SUCCESS = 0
-  GSL_FAILURE  = -1,
+  GSL_FAILURE  = -1
   GSL_CONTINUE = -2  # iteration has not converged
   GSL_EDOM     = 1   # input domain error, e.g sqrt(-1)
   GSL_ERANGE   = 2   # output range error, e.g. exp(1e100)

--- a/cython_gsl/gsl.pxd
+++ b/cython_gsl/gsl.pxd
@@ -2,6 +2,7 @@ cimport cython_gsl.math
 cimport cython_gsl.stdio
 cdef enum:
   GSL_SUCCESS = 0
+  GSL_FAILURE  = -1
   GSL_CONTINUE = -2  # iteration has not converged
   GSL_EDOM     = 1   # input domain error, e.g sqrt(-1)
   GSL_ERANGE   = 2   # output range error, e.g. exp(1e100)


### PR DESCRIPTION
Only GSL_SUCCESS was defined in CythonGSL as far as I could see, I added the rest
of them from gsl_errno.h
