### PR TITLE
* like to GSL for Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,8 @@ Dependencies
 
 * Python
 * Cython (http://cython.org)
-* GSL (for a windows port see
-  http://gnuwin32.sourceforge.net/packages/gsl.htm)
+* GSL (for a Windows port see
+  https://code.google.com/p/oscats/downloads/list)
 
 Installing CythonGSL
 ====================


### PR DESCRIPTION
The oscats project keeps newer version of GSL (1.15), and also 64-bit Windows DLL and Headers.
