### PR TITLE
Removing Cython.Distutils imports in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 from distutils.core import setup
-from Cython.Distutils import Extension
-from Cython.Distutils import build_ext
 
 setup(
     name="CythonGSL",


### PR DESCRIPTION
They are unused and they prevent users from installing Cython and
CythonGSL in a single `pip install` command.
`pip install Cython CythonGSL` fails because `pip` imports `setup.py`
from **all** packages before installing any of them.