### PR TITLE
Gsl errno

### DIFF
--- a/cython_gsl/gsl_errno.pxd
+++ b/cython_gsl/gsl_errno.pxd
@@ -1,5 +1,5 @@
 cdef extern from "gsl/gsl_errno.h":
     ctypedef void gsl_error_handler_t(const char * reason, const char * file,
                                       int line, int gsl_errno)
-    gsl_error_handler_t * gsl_set_error_handler (gsl_error_handler_t * new_handler)
-    gsl_error_handler_t * gsl_set_error_handler_off ()
+    gsl_error_handler_t * gsl_set_error_handler (gsl_error_handler_t * new_handler) nogil
+    gsl_error_handler_t * gsl_set_error_handler_off () nogil

--- a/cython_gsl/gsl_errno.pxd
+++ b/cython_gsl/gsl_errno.pxd
@@ -1,0 +1,5 @@
+cdef extern from "gsl/gsl_errno.h":
+    ctypedef void gsl_error_handler_t(const char * reason, const char * file,
+                                      int line, int gsl_errno)
+    gsl_error_handler_t * gsl_set_error_handler (gsl_error_handler_t * new_handler)
+    gsl_error_handler_t * gsl_set_error_handler_off ()

--- a/cython_gsl/test/gslerrno.pyx
+++ b/cython_gsl/test/gslerrno.pyx
@@ -1,0 +1,11 @@
+from cython_gsl cimport *
+from cython_gsl.gsl_errno cimport *
+
+
+def t_gsl_matrix_alloc_fail():
+    cdef gsl_matrix * m
+    h = gsl_set_error_handler_off()
+    #This will fail b/c cannot alloc dimension of 0
+    m = gsl_matrix_alloc (0, 3)
+    gsl_set_error_handler(h)
+

--- a/cython_gsl/test/test_errno.py
+++ b/cython_gsl/test/test_errno.py
@@ -1,0 +1,9 @@
+import unittest, gslerrno
+
+class ErrnoTest(unittest.TestCase):
+
+    def test_gsl_matrix_alloc_fail(self):
+        t = gslerrno.t_gsl_matrix_alloc_fail()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We are developing a large package that makes heavy use of cython_gsl.  We have run into issues when the GSL error handler is invoked & crashes the Python interpreter.  This PR exposes gsl/gsl_errno.h, allowing you to do error handling based on checking the return values, etc., as described [here](https://www.gnu.org/software/gsl/manual/html_node/Error-Handlers.html#Error-Handlers) and [here](https://www.gnu.org/software/gsl/manual/html_node/Error-Reporting.html#Error-Reporting).