### PR TITLE
use subprocess.CalledProcessError for try except clause

### DIFF
--- a/cython_gsl/__init__.py
+++ b/cython_gsl/__init__.py
@@ -21,7 +21,7 @@ import subprocess
 def get_include():
     try:
         gsl_include = subprocess.check_output('gsl-config --cflags', shell=True).decode('utf-8')[2:-1]
-    except OSError:
+    except subprocess.CalledProcessError:
         gsl_include = os.getenv('LIB_GSL')
         if gsl_include is None:
             # Environmental variable LIB_GSL not set, use hardcoded path.
@@ -37,7 +37,7 @@ def get_include():
 def get_library_dir():
     try:
         lib_gsl_dir = subprocess.check_output('gsl-config --libs', shell=True).decode('utf-8').split()[0][2:]
-    except OSError:
+    except subprocess.CalledProcessError:
         lib_gsl_dir = os.getenv('LIB_GSL')
         if lib_gsl_dir is None:
             # Environmental variable LIB_GSL not set, use hardcoded path.


### PR DESCRIPTION
Seems like the check from yesterday fails in some cases, this one should catch all troublesome cases.

Problem call currently will crash with

~~~python
In [33]: get_library_dir()
/bin/sh: 1: gsl-configdg: not found
---------------------------------------------------------------------------
CalledProcessError                        Traceback (most recent call last)
<ipython-input-33-f16cd545e271> in <module>()
----> 1 get_library_dir()

<ipython-input-32-bbcfba7f625b> in get_library_dir()
      1 def get_library_dir():
      2     try:
----> 3         lib_gsl_dir = subprocess.check_output('gsl-configdg --libs', shell=True).decode('utf-8').split()[0][2:]
      4     except OSError:
      5         lib_gsl_dir = os.getenv('LIB_GSL')

/home/samuel/anaconda3/lib/python3.5/subprocess.py in check_output(timeout, *popenargs, **kwargs)
    314 
    315     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
--> 316                **kwargs).stdout
    317 
    318 

/home/samuel/anaconda3/lib/python3.5/subprocess.py in run(input, timeout, check, *popenargs, **kwargs)
    396         if check and retcode:
    397             raise CalledProcessError(retcode, process.args,
--> 398                                      output=stdout, stderr=stderr)
    399     return CompletedProcess(process.args, retcode, stdout, stderr)
    400 

CalledProcessError: Command 'gsl-configdg --libs' returned non-zero exit status 127
~~~

This one will do 
~~~python
In [35]: get_library_dir()
/bin/sh: 1: gsl-configdg: not found
Out[35]: 'c:\\Program Files\\GnuWin32\\lib'
~~~

And go into the except clause as intended. The OSError must have been for the subprocess.popen thing, which was not always working for me. Sorry about the trouble.